### PR TITLE
Fix env variable mismatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ npm install
 
 3️⃣ **Create a `.env` File** and add Firebase & API Keys:
 ```
-REACT_APP_FIREBASE_API_KEY=your_firebase_api_key
+VITE_APP_FIREBASE_API_KEY=your_firebase_api_key
 REACT_APP_OPENAI_API_KEY=your_openai_api_key
 ```
 

--- a/src/firebase/firebase-config.jsx
+++ b/src/firebase/firebase-config.jsx
@@ -6,7 +6,7 @@ import { getStorage } from "firebase/storage"; // If using Firebase Storage
 import { getAnalytics } from "firebase/analytics"; // Optional for tracking
 
 const firebaseConfig = {
-  apiKey: import.meta.env.VITE_FIREBASE_API_KEY,
+  apiKey: import.meta.env.VITE_APP_FIREBASE_API_KEY,
   authDomain: "urbancart-6834a.firebaseapp.com",
   projectId: "urbancart-6834a",
   storageBucket: "urbancart-6834a.appspot.com",


### PR DESCRIPTION
## Summary
- use `VITE_APP_FIREBASE_API_KEY` in Firebase config
- update README env variable name

## Testing
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_685049bee1d483218c94bcd431ce3a3a