### PR TITLE
Fix SPA routing with nginx config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,9 @@ RUN npm run build
 # Use a lightweight nginx image to serve the built files
 FROM nginx:alpine
 
+# Provide custom nginx configuration to handle client-side routing
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+
 # Copy build output to nginx html directory
 COPY --from=build /app/dist /usr/share/nginx/html
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,10 @@ docker build -t urbancart .
 docker run -p 3000:80 urbancart
 ```
 
+The Docker image ships with a custom **nginx** configuration (`nginx.conf`) that
+redirects all unknown paths to `index.html`. This allows React Router to handle
+client-side routes even when the page is refreshed.
+
 
 ---
 

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,10 @@
+server {
+    listen 80;
+    server_name _;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}


### PR DESCRIPTION
## Summary
- add an nginx config to forward unknown routes to `index.html`
- copy that config in the Dockerfile
- document how the docker image uses the custom nginx setup

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68505cadba148321bffd474fe98ef929