### PR TITLE
Fix skeleton component import

### DIFF
--- a/src/components/ui/skeleton.jsx
+++ b/src/components/ui/skeleton.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+function Skeleton({ className = '' }) {
+  return (
+    <div className={`animate-pulse rounded-md bg-gray-200 dark:bg-gray-700 ${className}`}></div>
+  );
+}
+
+export { Skeleton };
+export default Skeleton;

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,7 +1,13 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import { resolve } from 'path'
 
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: {
+      '@': resolve(__dirname, 'src'),
+    },
+  },
 })


### PR DESCRIPTION
## Summary
- add missing `Skeleton` component under `src/components/ui`
- configure `@` alias in `vite.config.js` for src path

## Testing
- `npm run lint` *(fails: ESLint plugin not found)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851007e7ad48321976588e4f16d6c5f