### PR TITLE
Update error message design

### DIFF
--- a/src/components/FormErrorMessage.jsx
+++ b/src/components/FormErrorMessage.jsx
@@ -2,8 +2,11 @@ import React from 'react';
 
 const FormErrorMessage = ({ message }) => {
   return (
-    <div className="mt-2 bg-red-100 border border-red-400 text-red-700 py-1 px-1 rounded relative" role="alert">
-      <span className="block sm:inline">{message}</span>
+    <div
+      className="mt-2 bg-red-50 dark:bg-red-950/20 border border-red-200 dark:border-red-800 text-red-700 dark:text-red-400 py-2 px-3 rounded-lg relative animate-fade-in transition-all duration-200"
+      role="alert"
+    >
+      <span className="block sm:inline text-sm font-medium">{message}</span>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- tweak the FormErrorMessage component styles to match the new design

## Testing
- `npm run lint` *(fails: 133 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68524bd44dec832183e4b7a0b616a2d4