### PR TITLE
Improve product fade-in timing

### DIFF
--- a/src/components/ProductLists.jsx
+++ b/src/components/ProductLists.jsx
@@ -40,23 +40,26 @@ function ProductLists({ addToCart, setCartItems, cartItems, page }) {
     } else {
         return (
             <div className="rounded-2xl border-2 border-dashed border-gray-200 dark:border-gray-700 bg-gradient-to-br from-gray-50/30 to-white/80 dark:from-gray-900/30 dark:to-gray-800/50 lg:col-span-10 lg:col-start-3 lg:h-full mx-auto grid w-full max-w-full items-start space-y-6 px-8 py-12 md:grid-cols-2 md:gap-8 md:space-y-0 lg:grid-cols-2 xl:grid-cols-4 backdrop-blur-sm shadow-lg dark:shadow-2xl transition-all duration-500">
-                {allProductData.slice(0, 8 * page).map((item, index) => (
-                    <div
-                        key={index}
-                        className="opacity-0 translate-y-4 transition-all duration-500 ease-out"
-                        style={{
-                            animationDelay: `${index * 150}ms`,
-                            animationFillMode: 'forwards',
-                            animation: `fadeInUp 0.6s ease-out ${index * 150}ms forwards`,
-                        }}
-                    >
-                        <ProductCards
-                            addToCartToast={addToCart}
-                            item={item}
-                            handleProductClick={handleProductClick}
-                        />
-                    </div>
-                ))}
+                {allProductData.slice(0, 8 * page).map((item, index) => {
+                    const delay = (index % 8) * 150;
+                    return (
+                        <div
+                            key={index}
+                            className="opacity-0 translate-y-4 transition-all duration-500 ease-out"
+                            style={{
+                                animationDelay: `${delay}ms`,
+                                animationFillMode: 'forwards',
+                                animation: `fadeInUp 0.6s ease-out ${delay}ms forwards`,
+                            }}
+                        >
+                            <ProductCards
+                                addToCartToast={addToCart}
+                                item={item}
+                                handleProductClick={handleProductClick}
+                            />
+                        </div>
+                    );
+                })}
             </div>
         );
     }


### PR DESCRIPTION
## Summary
- limit fade-in delay per page when loading products

## Testing
- `npm run lint` *(fails: ESLint couldn't find plugin and numerous lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68524e5b04d48321b119d4cda5495c5a