### PR TITLE
Improve category filter layout

### DIFF
--- a/src/screens/ProductDisplay.jsx
+++ b/src/screens/ProductDisplay.jsx
@@ -38,21 +38,10 @@ const filters = [
 
 function ProductDisplay({ cartItems, setCartItems, addToCart, categoryAdded, categoryRemoved }) {
   const dispatch = useDispatch()
-  const [isAttached, setIsAttached] = useState(false)
   const [selectedCategories, setSelectedCategories] = useState([])
   const [lastSelectedCategory, setLastSelectedCategory] = useState('')
   const [page, setPage] = useState(1)
   const [sortBy, setSortBy] = useState('')
-
-  useEffect(() => {
-    const handleScroll = () => {
-      const scrollTop = window.pageYOffset
-      setIsAttached(scrollTop > 250)
-    }
-    if (window.pageYOffset > 250) setIsAttached(true)
-    window.addEventListener('scroll', handleScroll)
-    return () => window.removeEventListener('scroll', handleScroll)
-  }, [])
 
   useEffect(() => {
     if (selectedCategories.length === 0) {
@@ -254,13 +243,7 @@ function ProductDisplay({ cartItems, setCartItems, addToCart, categoryAdded, cat
         <div className="my-8 h-px bg-gradient-to-r from-transparent via-gray-300 dark:via-gray-600 to-transparent"></div>
 
         <div className="lg:grid lg:grid-cols-12 lg:gap-8">
-          <div
-            className={`${
-              isAttached
-                ? 'fixed top-6 z-20 w-64 transform transition-all duration-300 ease-in-out'
-                : 'lg:col-span-2 transform transition-all duration-300 ease-in-out'
-            } space-y-6`}
-          >
+          <div className="lg:col-span-2 lg:sticky lg:top-24 space-y-6">
             <div className="rounded-2xl border border-gray-200 dark:border-gray-700 bg-white/80 dark:bg-gray-800/80 p-6 shadow-lg backdrop-blur-sm">
               {filters.map((filter) => (
                 <div key={filter.id} className="space-y-4">


### PR DESCRIPTION
## Summary
- adjust ProductDisplay sidebar to use CSS sticky instead of JS scroll handling

## Testing
- `npm run lint` *(fails: 134 problems)*

------
https://chatgpt.com/codex/tasks/task_e_6853f8ef15a88321a6d1d447d124b6e7